### PR TITLE
Memory leak fix + memleak tracker

### DIFF
--- a/Test/LeakTracker.cs
+++ b/Test/LeakTracker.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test
+{
+    public static class LeakTracker
+    {
+        static List<WeakReference> _tracker = new List<WeakReference>();
+
+        /// <summary>
+        /// should be called only at object construction/instanciation
+        /// </summary>
+        public static void Add(object objToTrack)
+        {
+            Prune();
+            _tracker.Add(new WeakReference(objToTrack));
+        }
+
+        public static void Prune()
+        {
+            _tracker = _tracker.Where(o => o.IsAlive).ToList();
+        }
+
+        public static string Dump()
+        {
+            Prune();
+            return string.Join("\r\n", _tracker.Select(o => o.Target).Where(o => o != null).Select(o => o.GetType().ToString()));
+        }
+    }
+}

--- a/Test/MainPage.xaml.cs
+++ b/Test/MainPage.xaml.cs
@@ -34,7 +34,7 @@ namespace Test
         {
             base.OnNavigatedTo(e);
 
-            //bad but will ensure that all collectable object are collected.
+            //bad but will ensure that all collectable objects are collected.
             GC.Collect();
             Debug.WriteLine(LeakTracker.Dump());
         }

--- a/Test/MainPage.xaml.cs
+++ b/Test/MainPage.xaml.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Test.Tests;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -15,9 +17,26 @@ namespace Test
     {
         public MainPage()
         {
+            LeakTracker.Add(this);
             this.InitializeComponent();
 
             this.Loaded += MainPage_Loaded;
+            this.frame.Navigated += (a, e) =>
+            {
+                GC.Collect();
+                Debug.WriteLine(LeakTracker.Dump() + "\r\n");
+            };
+        }
+
+
+
+        protected override void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+
+            //bad but will ensure that all collectable object are collected.
+            GC.Collect();
+            Debug.WriteLine(LeakTracker.Dump());
         }
 
         private void MainPage_Loaded(object sender, RoutedEventArgs e)

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -108,6 +108,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="LeakTracker.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/Test/Tests/RefreshableListViewTest.xaml.cs
+++ b/Test/Tests/RefreshableListViewTest.xaml.cs
@@ -1,19 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Sample.Data;
+using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Sample.Data;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
@@ -29,8 +18,10 @@ namespace Test.Tests
         ObservableCollection<Item> Items;
         public RefreshableListViewTest()
         {
+            LeakTracker.Add(this);
             this.InitializeComponent();
             Items = new ObservableCollection<Item>();
+            this.NavigationCacheMode = NavigationCacheMode.Disabled;
             populateData();
         }
 

--- a/src/Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/src/Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -115,6 +115,8 @@ namespace Comet.Controls
                 RefreshIndicatorTransform.TranslateY = -RefreshIndicatorBorder.ActualHeight;
             };
 
+            //TODO : Uncomment to reveal memory leak in debug window : you will see multiple instance of the RefreshableListViewTest page
+            //CompositionTarget.Rendering += CompositionTarget_Rendering;
 
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
             {
@@ -137,6 +139,7 @@ namespace Comet.Controls
             // sometimes the value gets stuck at 0.something, so checking if less than 1
             if (Scroller.VerticalOffset < 1)
             {
+                //TODO : comment to reveal memory leak
                 CompositionTarget.Rendering += CompositionTarget_Rendering;
             }
         }
@@ -146,6 +149,7 @@ namespace Comet.Controls
         /// </summary>
         private void Scroller_DirectManipulationCompleted(object sender, object e)
         {
+            //TODO : Comment to reveal memory leak 
             CompositionTarget.Rendering -= CompositionTarget_Rendering;
             RefreshIndicatorTransform.TranslateY = -RefreshIndicatorBorder.ActualHeight;
             ContentTransform.TranslateY = 0;

--- a/src/Controls/PullToRefreshListView/PullToRefreshListView.cs
+++ b/src/Controls/PullToRefreshListView/PullToRefreshListView.cs
@@ -1,16 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Input;
 using Windows.Foundation;
 using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Media.Animation;
 
 namespace Comet.Controls
 {
@@ -67,7 +61,7 @@ namespace Comet.Controls
         /// Occurs when the user has requested content to be refreshed
         /// </summary>
         public event EventHandler RefreshRequested;
-        
+
         /// <summary>
         /// Occurs when listview overscroll distance is changed
         /// </summary>
@@ -120,13 +114,12 @@ namespace Comet.Controls
             {
                 RefreshIndicatorTransform.TranslateY = -RefreshIndicatorBorder.ActualHeight;
             };
-            
-            CompositionTarget.Rendering += CompositionTarget_Rendering;
+
 
             if (Windows.ApplicationModel.DesignMode.DesignModeEnabled)
             {
                 OverscrollMultiplier = OverscrollLimit * 10;
-            } 
+            }
             else
             {
                 OverscrollMultiplier = (OverscrollLimit * 10) / DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
@@ -143,7 +136,9 @@ namespace Comet.Controls
         {
             // sometimes the value gets stuck at 0.something, so checking if less than 1
             if (Scroller.VerticalOffset < 1)
-                manipulating = true;
+            {
+                CompositionTarget.Rendering += CompositionTarget_Rendering;
+            }
         }
 
         /// <summary>
@@ -151,7 +146,7 @@ namespace Comet.Controls
         /// </summary>
         private void Scroller_DirectManipulationCompleted(object sender, object e)
         {
-            manipulating = false;
+            CompositionTarget.Rendering -= CompositionTarget_Rendering;
             RefreshIndicatorTransform.TranslateY = -RefreshIndicatorBorder.ActualHeight;
             ContentTransform.TranslateY = 0;
 
@@ -182,12 +177,6 @@ namespace Comet.Controls
         /// <param name="e"></param>
         private void CompositionTarget_Rendering(object sender, object e)
         {
-            if (!manipulating) return;
-            //else if (Scroller.VerticalOffset > 0)
-            //{
-            //    manipulating = false;
-            //    return;
-            //}
             Rect elementBounds = ScrollerContent.TransformToVisual(Root).TransformBounds(new Rect());
 
             var offset = elementBounds.Y;


### PR DESCRIPTION
I saw that you already made the fix but i'm still issuing the pull request because I added a memory leak tracker (I always use that to track object lifespan when trying to investigate memory issues).

You can also get rid of "manipulating" flag, the inhibition of the CompositeTarget.Rendering code is now implicit by the event subscription / unsubscription.
